### PR TITLE
feature: txHash

### DIFF
--- a/dist/clients/rpc-client/kyve/base.v1beta1.d.ts
+++ b/dist/clients/rpc-client/kyve/base.v1beta1.d.ts
@@ -2,6 +2,7 @@ import { MsgClaimUploaderRole, MsgDefundPool, MsgDelegatePool, MsgFundPool, MsgS
 import { SigningStargateClient } from "@cosmjs/stargate";
 import { StdFee } from "@cosmjs/amino/build/signdoc";
 import { AccountData } from "@cosmjs/amino/build/signer";
+import { TxPromise } from "../../../utils";
 export default class KyveBaseMsg {
     private nativeClient;
     readonly account: AccountData;
@@ -9,47 +10,47 @@ export default class KyveBaseMsg {
     foundPool(value: Omit<MsgFundPool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     defundPool(value: Omit<MsgDefundPool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     stakePool(value: Omit<MsgStakePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     unstakePool(value: Omit<MsgUnstakePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     delegatePool(value: Omit<MsgDelegatePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     withdrawPool(value: Omit<MsgWithdrawPool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     undelegatePool(value: Omit<MsgUndelegatePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     submitBundleProposal(value: Omit<MsgSubmitBundleProposal, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     voteProposal(value: Omit<MsgVoteProposal, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     claimUploaderRole(value: Omit<MsgClaimUploaderRole, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     updateMetadata(value: Omit<MsgUpdateMetadata, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     transfer(recipient: string, amount: string, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;

--- a/dist/clients/rpc-client/kyve/base.v1beta1.js
+++ b/dist/clients/rpc-client/kyve/base.v1beta1.js
@@ -52,54 +52,176 @@ var tx_registry_1 = require("../../../registry/tx.registry");
 var bignumber_js_1 = require("bignumber.js");
 var constants_1 = require("../../../constants");
 var constants_2 = require("../../../constants");
+var utils_1 = require("../../../utils");
 var KyveBaseMsg = /** @class */ (function () {
     function KyveBaseMsg(client, account) {
         this.account = account;
         this.nativeClient = client;
     }
     KyveBaseMsg.prototype.foundPool = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.fundPool(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.fundPool(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.defundPool = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.defundPool(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.defundPool(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.stakePool = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.stakePool(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.stakePool(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.unstakePool = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.unstakePool(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.unstakePool(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.delegatePool = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.delegatePool(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.delegatePool(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.withdrawPool = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.withdrawPool(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.withdrawPool(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.undelegatePool = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.undelegatePool(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.undelegatePool(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.submitBundleProposal = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.submitBundleProposal(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.submitBundleProposal(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.voteProposal = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.voteProposal(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.voteProposal(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.claimUploaderRole = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.claimUploaderRole(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.claimUploaderRole(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.updateMetadata = function (value, options) {
-        var tx = tx_registry_1.withTypeUrl.updateMetadata(__assign(__assign({}, value), { creator: this.account.address }));
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        tx = tx_registry_1.withTypeUrl.updateMetadata(__assign(__assign({}, value), { creator: this.account.address }));
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveBaseMsg.prototype.transfer = function (recipient, amount, options) {
         return __awaiter(this, void 0, void 0, function () {

--- a/dist/clients/rpc-client/kyve/gov.v1beta1.d.ts
+++ b/dist/clients/rpc-client/kyve/gov.v1beta1.d.ts
@@ -4,6 +4,7 @@ import { AccountData } from "@cosmjs/amino/build/signer";
 import { TextProposal } from "@kyve/proto/dist/proto/cosmos/gov/v1beta1/gov";
 import { ParameterChangeProposal } from "@kyve/proto/dist/proto/cosmos/params/v1beta1/params";
 import { CancelPoolUpgradeProposal, PausePoolProposal, SchedulePoolUpgradeProposal, UnpausePoolProposal, UpdatePoolProposal } from "@kyve/proto/dist/proto/kyve/registry/v1beta1/gov";
+import { TxPromise } from "../../../utils";
 export default class KyveGovMsg {
     private nativeClient;
     readonly account: AccountData;
@@ -13,35 +14,35 @@ export default class KyveGovMsg {
         fee?: StdFee | "auto" | number;
         memo?: string;
         isExpedited?: boolean;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     parameterChangeProposal(amount: string, value: ParameterChangeProposal, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
         isExpedited?: boolean;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     updatePoolProposal(amount: string, value: UpdatePoolProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     pausePoolProposal(amount: string, value: PausePoolProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     unpausePoolProposal(amount: string, value: UnpausePoolProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     schedulePoolUpgradeProposal(amount: string, value: SchedulePoolUpgradeProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
     cancelPoolUpgradeProposal(amount: string, value: CancelPoolUpgradeProposal, options: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    }): Promise<TxPromise>;
 }

--- a/dist/clients/rpc-client/kyve/gov.v1beta1.js
+++ b/dist/clients/rpc-client/kyve/gov.v1beta1.js
@@ -1,10 +1,47 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 exports.__esModule = true;
 var stargate_1 = require("@cosmjs/stargate");
 var constants_1 = require("../../../constants");
 var gov_1 = require("@kyve/proto/dist/proto/cosmos/gov/v1beta1/gov");
 var params_1 = require("@kyve/proto/dist/proto/cosmos/params/v1beta1/params");
 var gov_2 = require("@kyve/proto/dist/proto/kyve/registry/v1beta1/gov");
+var utils_1 = require("../../../utils");
 var KyveGovMsg = /** @class */ (function () {
     function KyveGovMsg(client, account) {
         this.account = account;
@@ -23,60 +60,137 @@ var KyveGovMsg = /** @class */ (function () {
         };
     };
     KyveGovMsg.prototype.submitTextProposal = function (amount, value, options) {
-        var content = {
-            typeUrl: "/cosmos.gov.v1beta1.TextProposal",
-            value: gov_1.TextProposal.encode(value).finish()
-        };
-        var tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var content, tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        content = {
+                            typeUrl: "/cosmos.gov.v1beta1.TextProposal",
+                            value: gov_1.TextProposal.encode(value).finish()
+                        };
+                        tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveGovMsg.prototype.parameterChangeProposal = function (amount, value, options) {
-        var content = {
-            typeUrl: "/cosmos.params.v1beta1.ParameterChangeProposal",
-            value: params_1.ParameterChangeProposal.encode(value).finish()
-        };
-        var tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var content, tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        content = {
+                            typeUrl: "/cosmos.params.v1beta1.ParameterChangeProposal",
+                            value: params_1.ParameterChangeProposal.encode(value).finish()
+                        };
+                        tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveGovMsg.prototype.updatePoolProposal = function (amount, value, options) {
-        var content = {
-            typeUrl: "/kyve.registry.v1beta1.UpdatePoolProposal",
-            value: gov_2.UpdatePoolProposal.encode(value).finish()
-        };
-        var tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var content, tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        content = {
+                            typeUrl: "/kyve.registry.v1beta1.UpdatePoolProposal",
+                            value: gov_2.UpdatePoolProposal.encode(value).finish()
+                        };
+                        tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveGovMsg.prototype.pausePoolProposal = function (amount, value, options) {
-        var content = {
-            typeUrl: "/kyve.registry.v1beta1.PausePoolProposal",
-            value: gov_2.PausePoolProposal.encode(value).finish()
-        };
-        var tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var content, tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        content = {
+                            typeUrl: "/kyve.registry.v1beta1.PausePoolProposal",
+                            value: gov_2.PausePoolProposal.encode(value).finish()
+                        };
+                        tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveGovMsg.prototype.unpausePoolProposal = function (amount, value, options) {
-        var content = {
-            typeUrl: "/kyve.registry.v1beta1.UnpausePoolProposal",
-            value: gov_2.UnpausePoolProposal.encode(value).finish()
-        };
-        var tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var content, tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        content = {
+                            typeUrl: "/kyve.registry.v1beta1.UnpausePoolProposal",
+                            value: gov_2.UnpausePoolProposal.encode(value).finish()
+                        };
+                        tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveGovMsg.prototype.schedulePoolUpgradeProposal = function (amount, value, options) {
-        var content = {
-            typeUrl: "/kyve.registry.v1beta1.SchedulePoolUpgradeProposal",
-            value: gov_2.SchedulePoolUpgradeProposal.encode(value).finish()
-        };
-        var tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var content, tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        content = {
+                            typeUrl: "/kyve.registry.v1beta1.SchedulePoolUpgradeProposal",
+                            value: gov_2.SchedulePoolUpgradeProposal.encode(value).finish()
+                        };
+                        tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     KyveGovMsg.prototype.cancelPoolUpgradeProposal = function (amount, value, options) {
-        var content = {
-            typeUrl: "/kyve.registry.v1beta1.CancelPoolUpgradeProposal",
-            value: gov_2.CancelPoolUpgradeProposal.encode(value).finish()
-        };
-        var tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
-        return this.nativeClient.signAndBroadcast(this.account.address, [tx], (options === null || options === void 0 ? void 0 : options.fee) ? options === null || options === void 0 ? void 0 : options.fee : "auto", options === null || options === void 0 ? void 0 : options.memo);
+        return __awaiter(this, void 0, void 0, function () {
+            var content, tx, _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        content = {
+                            typeUrl: "/kyve.registry.v1beta1.CancelPoolUpgradeProposal",
+                            value: gov_2.CancelPoolUpgradeProposal.encode(value).finish()
+                        };
+                        tx = this.createGovTx(amount, content, options === null || options === void 0 ? void 0 : options.isExpedited);
+                        _a = utils_1.TxPromise.bind;
+                        _b = [void 0, this.nativeClient];
+                        return [4 /*yield*/, (0, utils_1.signTx)(this.nativeClient, this.account.address, tx, options)];
+                    case 1: return [2 /*return*/, new (_a.apply(utils_1.TxPromise, _b.concat([_c.sent()])))()];
+                }
+            });
+        });
     };
     return KyveGovMsg;
 }());

--- a/src/clients/rpc-client/kyve/base.v1beta1.ts
+++ b/src/clients/rpc-client/kyve/base.v1beta1.ts
@@ -29,7 +29,7 @@ export default class KyveBaseMsg {
     this.nativeClient = client;
   }
 
-   public async foundPool(
+   public async fundPool(
     value: Omit<MsgFundPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;

--- a/src/clients/rpc-client/kyve/base.v1beta1.ts
+++ b/src/clients/rpc-client/kyve/base.v1beta1.ts
@@ -11,14 +11,14 @@ import {
   MsgVoteProposal,
   MsgWithdrawPool,
 } from "@kyve/proto/dist/proto/kyve/registry/v1beta1/tx";
-import { coins, SigningStargateClient} from "@cosmjs/stargate";
+import { coins, SigningStargateClient } from "@cosmjs/stargate";
 import { StdFee } from "@cosmjs/amino/build/signdoc";
 import { withTypeUrl } from "../../../registry/tx.registry";
 import { AccountData } from "@cosmjs/amino/build/signer";
 import { BigNumber } from "bignumber.js";
 import { KYVE_DECIMALS } from "../../../constants";
 import { DENOM } from "../../../constants";
-import {signTx, TxPromise} from "../../../utils";
+import { signTx, TxPromise } from "../../../utils";
 
 export default class KyveBaseMsg {
   private nativeClient: SigningStargateClient;
@@ -29,7 +29,7 @@ export default class KyveBaseMsg {
     this.nativeClient = client;
   }
 
-   public async fundPool(
+  public async fundPool(
     value: Omit<MsgFundPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -40,8 +40,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-     return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-   }
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
+  }
 
   public async defundPool(
     value: Omit<MsgDefundPool, "creator">,
@@ -54,8 +57,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async stakePool(
@@ -69,8 +74,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async unstakePool(
@@ -84,8 +91,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async delegatePool(
@@ -99,8 +108,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async withdrawPool(
@@ -114,8 +125,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async undelegatePool(
@@ -129,8 +142,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async submitBundleProposal(
@@ -144,8 +159,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async voteProposal(
@@ -159,8 +176,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async claimUploaderRole(
@@ -174,8 +193,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async updateMetadata(
@@ -189,8 +210,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   async transfer(

--- a/src/clients/rpc-client/kyve/base.v1beta1.ts
+++ b/src/clients/rpc-client/kyve/base.v1beta1.ts
@@ -11,13 +11,14 @@ import {
   MsgVoteProposal,
   MsgWithdrawPool,
 } from "@kyve/proto/dist/proto/kyve/registry/v1beta1/tx";
-import { coins, SigningStargateClient } from "@cosmjs/stargate";
+import { coins, SigningStargateClient} from "@cosmjs/stargate";
 import { StdFee } from "@cosmjs/amino/build/signdoc";
 import { withTypeUrl } from "../../../registry/tx.registry";
 import { AccountData } from "@cosmjs/amino/build/signer";
 import { BigNumber } from "bignumber.js";
 import { KYVE_DECIMALS } from "../../../constants";
 import { DENOM } from "../../../constants";
+import {signTx, TxPromise} from "../../../utils";
 
 export default class KyveBaseMsg {
   private nativeClient: SigningStargateClient;
@@ -28,7 +29,7 @@ export default class KyveBaseMsg {
     this.nativeClient = client;
   }
 
-  public foundPool(
+   public async foundPool(
     value: Omit<MsgFundPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -39,15 +40,10 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
-  }
+     return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+   }
 
-  public defundPool(
+  public async defundPool(
     value: Omit<MsgDefundPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -58,15 +54,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public stakePool(
+  public async stakePool(
     value: Omit<MsgStakePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -77,15 +69,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public unstakePool(
+  public async unstakePool(
     value: Omit<MsgUnstakePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -96,15 +84,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public delegatePool(
+  public async delegatePool(
     value: Omit<MsgDelegatePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -115,15 +99,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public withdrawPool(
+  public async withdrawPool(
     value: Omit<MsgWithdrawPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -134,15 +114,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public undelegatePool(
+  public async undelegatePool(
     value: Omit<MsgUndelegatePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -153,15 +129,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public submitBundleProposal(
+  public async submitBundleProposal(
     value: Omit<MsgSubmitBundleProposal, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -172,15 +144,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public voteProposal(
+  public async voteProposal(
     value: Omit<MsgVoteProposal, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -191,15 +159,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public claimUploaderRole(
+  public async claimUploaderRole(
     value: Omit<MsgClaimUploaderRole, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -210,15 +174,11 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public updateMetadata(
+  public async updateMetadata(
     value: Omit<MsgUpdateMetadata, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -229,12 +189,8 @@ export default class KyveBaseMsg {
       ...value,
       creator: this.account.address,
     });
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
   async transfer(

--- a/src/clients/rpc-client/kyve/gov.v1beta1.ts
+++ b/src/clients/rpc-client/kyve/gov.v1beta1.ts
@@ -1,4 +1,4 @@
-import { coins, SigningStargateClient } from "@cosmjs/stargate";
+import { coins, SigningStargateClient} from "@cosmjs/stargate";
 import { StdFee } from "@cosmjs/amino/build/signdoc";
 import { AccountData } from "@cosmjs/amino/build/signer";
 import { DENOM } from "../../../constants";
@@ -11,6 +11,7 @@ import {
   UnpausePoolProposal,
   UpdatePoolProposal,
 } from "@kyve/proto/dist/proto/kyve/registry/v1beta1/gov";
+import {signTx, TxPromise} from "../../../utils";
 
 export default class KyveGovMsg {
   private nativeClient: SigningStargateClient;
@@ -37,7 +38,7 @@ export default class KyveGovMsg {
     };
   }
 
-  public submitTextProposal(
+  public async submitTextProposal(
     amount: string,
     value: TextProposal,
     options?: {
@@ -51,15 +52,10 @@ export default class KyveGovMsg {
       value: TextProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
   }
 
-  public parameterChangeProposal(
+  public async parameterChangeProposal(
     amount: string,
     value: ParameterChangeProposal,
     options?: {
@@ -73,15 +69,10 @@ export default class KyveGovMsg {
       value: ParameterChangeProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
   }
 
-  public updatePoolProposal(
+  public async updatePoolProposal(
     amount: string,
     value: UpdatePoolProposal,
     options?: {
@@ -95,15 +86,11 @@ export default class KyveGovMsg {
       value: UpdatePoolProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public pausePoolProposal(
+  public async pausePoolProposal(
     amount: string,
     value: PausePoolProposal,
     options?: {
@@ -117,15 +104,11 @@ export default class KyveGovMsg {
       value: PausePoolProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public unpausePoolProposal(
+  public async unpausePoolProposal(
     amount: string,
     value: UnpausePoolProposal,
     options?: {
@@ -139,15 +122,10 @@ export default class KyveGovMsg {
       value: UnpausePoolProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
   }
 
-  public schedulePoolUpgradeProposal(
+  public async schedulePoolUpgradeProposal(
     amount: string,
     value: SchedulePoolUpgradeProposal,
     options?: {
@@ -161,15 +139,11 @@ export default class KyveGovMsg {
       value: SchedulePoolUpgradeProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+
   }
 
-  public cancelPoolUpgradeProposal(
+  public async cancelPoolUpgradeProposal(
     amount: string,
     value: CancelPoolUpgradeProposal,
     options: {
@@ -183,11 +157,6 @@ export default class KyveGovMsg {
       value: CancelPoolUpgradeProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return this.nativeClient.signAndBroadcast(
-      this.account.address,
-      [tx],
-      options?.fee ? options?.fee : "auto",
-      options?.memo
-    );
+    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
   }
 }

--- a/src/clients/rpc-client/kyve/gov.v1beta1.ts
+++ b/src/clients/rpc-client/kyve/gov.v1beta1.ts
@@ -1,4 +1,4 @@
-import { coins, SigningStargateClient} from "@cosmjs/stargate";
+import { coins, SigningStargateClient } from "@cosmjs/stargate";
 import { StdFee } from "@cosmjs/amino/build/signdoc";
 import { AccountData } from "@cosmjs/amino/build/signer";
 import { DENOM } from "../../../constants";
@@ -11,7 +11,7 @@ import {
   UnpausePoolProposal,
   UpdatePoolProposal,
 } from "@kyve/proto/dist/proto/kyve/registry/v1beta1/gov";
-import {signTx, TxPromise} from "../../../utils";
+import { signTx, TxPromise } from "../../../utils";
 
 export default class KyveGovMsg {
   private nativeClient: SigningStargateClient;
@@ -52,7 +52,10 @@ export default class KyveGovMsg {
       value: TextProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async parameterChangeProposal(
@@ -69,7 +72,10 @@ export default class KyveGovMsg {
       value: ParameterChangeProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async updatePoolProposal(
@@ -86,8 +92,10 @@ export default class KyveGovMsg {
       value: UpdatePoolProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async pausePoolProposal(
@@ -104,8 +112,10 @@ export default class KyveGovMsg {
       value: PausePoolProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async unpausePoolProposal(
@@ -122,7 +132,10 @@ export default class KyveGovMsg {
       value: UnpausePoolProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async schedulePoolUpgradeProposal(
@@ -139,8 +152,10 @@ export default class KyveGovMsg {
       value: SchedulePoolUpgradeProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
-
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 
   public async cancelPoolUpgradeProposal(
@@ -157,6 +172,9 @@ export default class KyveGovMsg {
       value: CancelPoolUpgradeProposal.encode(value).finish(),
     };
     const tx = this.createGovTx(amount, content, options?.isExpedited);
-    return new TxPromise(this.nativeClient, await signTx(this.nativeClient, this.account.address,  tx, options))
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, tx, options)
+    );
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,47 +1,70 @@
-import {cosmos} from "@keplr-wallet/cosmos";
-import {EncodeObject} from "@cosmjs/proto-signing";
+import { cosmos } from "@keplr-wallet/cosmos";
+import { EncodeObject } from "@cosmjs/proto-signing";
 import TxRaw = cosmos.tx.v1beta1.TxRaw;
-import {toHex} from "@cosmjs/encoding";
-import {sha256} from "@cosmjs/crypto";
-import {calculateFee, SigningStargateClient} from "@cosmjs/stargate";
-import {StdFee} from "@cosmjs/amino/build/signdoc";
+import { toHex } from "@cosmjs/encoding";
+import { sha256 } from "@cosmjs/crypto";
+import { calculateFee, SigningStargateClient } from "@cosmjs/stargate";
+import { StdFee } from "@cosmjs/amino/build/signdoc";
 
 export class TxPromise {
-    private nativeClient: SigningStargateClient;
-    private txBytes: Uint8Array;
-    readonly txHash: string
-    constructor(nativeClient: SigningStargateClient, txBytes: Uint8Array) {
-        this.nativeClient = nativeClient
-        this.txBytes = txBytes
-        this.txHash = toHex(sha256(this.txBytes)).toUpperCase()
-
-    }
-    async execute() {
-        return await this.nativeClient.broadcastTx(this.txBytes)
-    }
+  private nativeClient: SigningStargateClient;
+  private txBytes: Uint8Array;
+  readonly txHash: string;
+  constructor(nativeClient: SigningStargateClient, txBytes: Uint8Array) {
+    this.nativeClient = nativeClient;
+    this.txBytes = txBytes;
+    this.txHash = toHex(sha256(this.txBytes)).toUpperCase();
+  }
+  async execute() {
+    return await this.nativeClient.broadcastTx(this.txBytes);
+  }
 }
 
 async function calcFee(gasEstimation: number, fee: "auto" | number) {
-    const multiplier = typeof fee === "number" ? fee : 1.3;
-    return calculateFee(Math.round(gasEstimation * multiplier), "0tkyve");
+  const multiplier = typeof fee === "number" ? fee : 1.3;
+  return calculateFee(Math.round(gasEstimation * multiplier), "0tkyve");
 }
 
-export async function signTx(nativeClient: SigningStargateClient, address: string, tx: EncodeObject, options?: {
+export async function signTx(
+  nativeClient: SigningStargateClient,
+  address: string,
+  tx: EncodeObject,
+  options?: {
     fee?: StdFee | "auto" | number;
     memo?: string;
-}) {
-    if(!options || options.fee == undefined) {
-        const gasEstimation = await nativeClient.simulate(address, [tx], undefined);
-        const fee = await calcFee(gasEstimation, 'auto')
-        const txRaw = await nativeClient.sign(address, [tx], fee, options?.memo ? options?.memo : "" )
-        return TxRaw.encode(txRaw).finish();
-    }else if (options.fee === 'auto' || typeof options.fee == "number") {
-        const gasEstimation = await nativeClient.simulate(address, [tx], options?.memo);
-        const fee = await calcFee(gasEstimation, options.fee)
-        const txRaw = await nativeClient.sign(address, [tx], fee, options?.memo ? options?.memo : "")
-        return TxRaw.encode(txRaw).finish();
-    } else {
-        const txRaw = await nativeClient.sign(address, [tx], options.fee, options?.memo ? options?.memo : "")
-        return TxRaw.encode(txRaw).finish();
-    }
+  }
+) {
+  if (!options || options.fee == undefined) {
+    const gasEstimation = await nativeClient.simulate(address, [tx], undefined);
+    const fee = await calcFee(gasEstimation, "auto");
+    const txRaw = await nativeClient.sign(
+      address,
+      [tx],
+      fee,
+      options?.memo ? options?.memo : ""
+    );
+    return TxRaw.encode(txRaw).finish();
+  } else if (options.fee === "auto" || typeof options.fee == "number") {
+    const gasEstimation = await nativeClient.simulate(
+      address,
+      [tx],
+      options?.memo
+    );
+    const fee = await calcFee(gasEstimation, options.fee);
+    const txRaw = await nativeClient.sign(
+      address,
+      [tx],
+      fee,
+      options?.memo ? options?.memo : ""
+    );
+    return TxRaw.encode(txRaw).finish();
+  } else {
+    const txRaw = await nativeClient.sign(
+      address,
+      [tx],
+      options.fee,
+      options?.memo ? options?.memo : ""
+    );
+    return TxRaw.encode(txRaw).finish();
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,47 @@
+import {cosmos} from "@keplr-wallet/cosmos";
+import {EncodeObject} from "@cosmjs/proto-signing";
+import TxRaw = cosmos.tx.v1beta1.TxRaw;
+import {toHex} from "@cosmjs/encoding";
+import {sha256} from "@cosmjs/crypto";
+import {calculateFee, SigningStargateClient} from "@cosmjs/stargate";
+import {StdFee} from "@cosmjs/amino/build/signdoc";
+
+export class TxPromise {
+    private nativeClient: SigningStargateClient;
+    private txBytes: Uint8Array;
+    readonly txHash: string
+    constructor(nativeClient: SigningStargateClient, txBytes: Uint8Array) {
+        this.nativeClient = nativeClient
+        this.txBytes = txBytes
+        this.txHash = toHex(sha256(this.txBytes)).toUpperCase()
+
+    }
+    async execute() {
+        return await this.nativeClient.broadcastTx(this.txBytes)
+    }
+}
+
+async function calcFee(gasEstimation: number, fee: "auto" | number) {
+    const multiplier = typeof fee === "number" ? fee : 1.3;
+    return calculateFee(Math.round(gasEstimation * multiplier), "0tkyve");
+}
+
+export async function signTx(nativeClient: SigningStargateClient, address: string, tx: EncodeObject, options?: {
+    fee?: StdFee | "auto" | number;
+    memo?: string;
+}) {
+    if(!options || options.fee == undefined) {
+        const gasEstimation = await nativeClient.simulate(address, [tx], undefined);
+        const fee = await calcFee(gasEstimation, 'auto')
+        const txRaw = await nativeClient.sign(address, [tx], fee, options?.memo ? options?.memo : "" )
+        return TxRaw.encode(txRaw).finish();
+    }else if (options.fee === 'auto' || typeof options.fee == "number") {
+        const gasEstimation = await nativeClient.simulate(address, [tx], options?.memo);
+        const fee = await calcFee(gasEstimation, options.fee)
+        const txRaw = await nativeClient.sign(address, [tx], fee, options?.memo ? options?.memo : "")
+        return TxRaw.encode(txRaw).finish();
+    } else {
+        const txRaw = await nativeClient.sign(address, [tx], options.fee, options?.memo ? options?.memo : "")
+        return TxRaw.encode(txRaw).finish();
+    }
+}

--- a/test/unit/kyve-client.test.ts
+++ b/test/unit/kyve-client.test.ts
@@ -28,7 +28,7 @@ import {
 } from "@kyve/proto/dist/proto/kyve/registry/v1beta1/gov";
 import BigNumber from "bignumber.js";
 import { SigningStargateClient } from "@cosmjs/stargate";
-import {cosmos} from "@keplr-wallet/cosmos";
+import { cosmos } from "@keplr-wallet/cosmos";
 import TxRaw = cosmos.tx.v1beta1.TxRaw;
 const PATH_TO_TYPES =
   "./node_modules/@kyve/proto/dist/proto/kyve/registry/v1beta1";
@@ -184,7 +184,7 @@ describe("Base Methods", () => {
         tx.value
       );
       expect(validationResult.valid).toBeTruthy();
-      expect(Object.keys(fee).sort()).toEqual(['amount', 'gas'].sort())
+      expect(Object.keys(fee).sort()).toEqual(["amount", "gas"].sort());
     });
   });
 
@@ -284,7 +284,7 @@ describe("Gov methods", () => {
         })
       );
 
-      expect(Object.keys(fee).sort()).toEqual(['amount', 'gas'].sort())
+      expect(Object.keys(fee).sort()).toEqual(["amount", "gas"].sort());
       expect(method.decoder.decode(tx.value.content.value)).toEqual(govParam);
     });
   });

--- a/test/unit/kyve-client.test.ts
+++ b/test/unit/kyve-client.test.ts
@@ -50,7 +50,7 @@ const TEST_AMOUNT = "1000000000";
 const validator = createValidator(typesFiles);
 const BaseMethods = [
   {
-    methodName: "foundPool",
+    methodName: "fundPool",
     parameters: {
       params: MsgFundPool.fromJSON({}),
       schema: validator.typeQuerySchemas.getSchemaForSymbol("MsgFundPool"),


### PR DESCRIPTION
Example:
```
(async function () {
    const sdk = new KyveSDK("alpha");
    const kyveClient = await sdk.fromMnemonic(TEST_MNEMONIC);
    const tx = await kyveClient.kyve.v1beta1.gov.submitTextProposal('100000', {
        title: '123123',
        description: '123123'
    }, {memo: "memorial"})
    console.log(tx.txHash);
    const res = await tx.execute() //return a DeliverTxResponse
})()
```

creates a proper txHash which corresponds to hash in explorer.   
https://explorer.beta.kyve.network/kyve-alphanet/tx/4BD7D28A6640FC937B8CE534F9D6055CCB76EDC152CBB8B65E5694F7A1615346
@troykessler If it fits your purposes feel free to merge. Also, all tests are fixed  : ) 