### PR TITLE
feature: thenable

### DIFF
--- a/dist/clients/rpc-client/kyve/base.v1beta1.d.ts
+++ b/dist/clients/rpc-client/kyve/base.v1beta1.d.ts
@@ -2,55 +2,54 @@ import { MsgClaimUploaderRole, MsgDefundPool, MsgDelegatePool, MsgFundPool, MsgS
 import { SigningStargateClient } from "@cosmjs/stargate";
 import { StdFee } from "@cosmjs/amino/build/signdoc";
 import { AccountData } from "@cosmjs/amino/build/signer";
-import { TxPromise } from "../../../utils";
 export default class KyveBaseMsg {
     private nativeClient;
     readonly account: AccountData;
     constructor(client: SigningStargateClient, account: AccountData);
-    foundPool(value: Omit<MsgFundPool, "creator">, options?: {
+    fundPool(value: Omit<MsgFundPool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     defundPool(value: Omit<MsgDefundPool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     stakePool(value: Omit<MsgStakePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     unstakePool(value: Omit<MsgUnstakePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     delegatePool(value: Omit<MsgDelegatePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     withdrawPool(value: Omit<MsgWithdrawPool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     undelegatePool(value: Omit<MsgUndelegatePool, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     submitBundleProposal(value: Omit<MsgSubmitBundleProposal, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     voteProposal(value: Omit<MsgVoteProposal, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     claimUploaderRole(value: Omit<MsgClaimUploaderRole, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     updateMetadata(value: Omit<MsgUpdateMetadata, "creator">, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     transfer(recipient: string, amount: string, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;

--- a/dist/clients/rpc-client/kyve/base.v1beta1.js
+++ b/dist/clients/rpc-client/kyve/base.v1beta1.js
@@ -58,7 +58,7 @@ var KyveBaseMsg = /** @class */ (function () {
         this.account = account;
         this.nativeClient = client;
     }
-    KyveBaseMsg.prototype.foundPool = function (value, options) {
+    KyveBaseMsg.prototype.fundPool = function (value, options) {
         return __awaiter(this, void 0, void 0, function () {
             var tx, _a, _b;
             return __generator(this, function (_c) {

--- a/dist/clients/rpc-client/kyve/gov.v1beta1.d.ts
+++ b/dist/clients/rpc-client/kyve/gov.v1beta1.d.ts
@@ -4,7 +4,6 @@ import { AccountData } from "@cosmjs/amino/build/signer";
 import { TextProposal } from "@kyve/proto/dist/proto/cosmos/gov/v1beta1/gov";
 import { ParameterChangeProposal } from "@kyve/proto/dist/proto/cosmos/params/v1beta1/params";
 import { CancelPoolUpgradeProposal, PausePoolProposal, SchedulePoolUpgradeProposal, UnpausePoolProposal, UpdatePoolProposal } from "@kyve/proto/dist/proto/kyve/registry/v1beta1/gov";
-import { TxPromise } from "../../../utils";
 export default class KyveGovMsg {
     private nativeClient;
     readonly account: AccountData;
@@ -14,35 +13,35 @@ export default class KyveGovMsg {
         fee?: StdFee | "auto" | number;
         memo?: string;
         isExpedited?: boolean;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     parameterChangeProposal(amount: string, value: ParameterChangeProposal, options?: {
         fee?: StdFee | "auto" | number;
         memo?: string;
         isExpedited?: boolean;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     updatePoolProposal(amount: string, value: UpdatePoolProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     pausePoolProposal(amount: string, value: PausePoolProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     unpausePoolProposal(amount: string, value: UnpausePoolProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     schedulePoolUpgradeProposal(amount: string, value: SchedulePoolUpgradeProposal, options?: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
     cancelPoolUpgradeProposal(amount: string, value: CancelPoolUpgradeProposal, options: {
         isExpedited?: boolean;
         fee?: StdFee | "auto" | number;
         memo?: string;
-    }): Promise<TxPromise>;
+    }): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
 }

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,12 +1,14 @@
 import { EncodeObject } from "@cosmjs/proto-signing";
 import { SigningStargateClient } from "@cosmjs/stargate";
 import { StdFee } from "@cosmjs/amino/build/signdoc";
+import { DeliverTxResponse } from "@cosmjs/stargate/build/stargateclient";
 export declare class TxPromise {
     private nativeClient;
     private txBytes;
     readonly txHash: string;
     constructor(nativeClient: SigningStargateClient, txBytes: Uint8Array);
-    execute(): Promise<import("@cosmjs/stargate").DeliverTxResponse>;
+    execute(): Promise<DeliverTxResponse>;
+    then(resolve: (arg: DeliverTxResponse) => void, reject: (arg: Error) => void): Promise<void>;
 }
 export declare function signTx(nativeClient: SigningStargateClient, address: string, tx: EncodeObject, options?: {
     fee?: StdFee | "auto" | number;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -58,6 +58,9 @@ var TxPromise = /** @class */ (function () {
             });
         });
     };
+    TxPromise.prototype.then = function (resolve, reject) {
+        return this.nativeClient.broadcastTx(this.txBytes).then(resolve)["catch"](reject);
+    };
     return TxPromise;
 }());
 exports.TxPromise = TxPromise;

--- a/src/clients/rpc-client/kyve/base.v1beta1.ts
+++ b/src/clients/rpc-client/kyve/base.v1beta1.ts
@@ -29,7 +29,7 @@ export default class KyveBaseMsg {
     this.nativeClient = client;
   }
 
-  public async fundPool(
+  public fundPool(
     value: Omit<MsgFundPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -42,11 +42,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async defundPool(
+  public defundPool(
     value: Omit<MsgDefundPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -59,11 +59,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async stakePool(
+  public stakePool(
     value: Omit<MsgStakePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -76,11 +76,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async unstakePool(
+  public unstakePool(
     value: Omit<MsgUnstakePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -93,11 +93,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async delegatePool(
+  public delegatePool(
     value: Omit<MsgDelegatePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -110,11 +110,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async withdrawPool(
+  public withdrawPool(
     value: Omit<MsgWithdrawPool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -127,11 +127,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async undelegatePool(
+  public undelegatePool(
     value: Omit<MsgUndelegatePool, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -144,11 +144,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async submitBundleProposal(
+  public submitBundleProposal(
     value: Omit<MsgSubmitBundleProposal, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -161,11 +161,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async voteProposal(
+  public voteProposal(
     value: Omit<MsgVoteProposal, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -178,11 +178,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async claimUploaderRole(
+  public claimUploaderRole(
     value: Omit<MsgClaimUploaderRole, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -195,11 +195,11 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async updateMetadata(
+  public updateMetadata(
     value: Omit<MsgUpdateMetadata, "creator">,
     options?: {
       fee?: StdFee | "auto" | number;
@@ -212,7 +212,7 @@ export default class KyveBaseMsg {
     });
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 

--- a/src/clients/rpc-client/kyve/gov.v1beta1.ts
+++ b/src/clients/rpc-client/kyve/gov.v1beta1.ts
@@ -38,7 +38,7 @@ export default class KyveGovMsg {
     };
   }
 
-  public async submitTextProposal(
+  public submitTextProposal(
     amount: string,
     value: TextProposal,
     options?: {
@@ -54,11 +54,11 @@ export default class KyveGovMsg {
     const tx = this.createGovTx(amount, content, options?.isExpedited);
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async parameterChangeProposal(
+  public parameterChangeProposal(
     amount: string,
     value: ParameterChangeProposal,
     options?: {
@@ -74,11 +74,11 @@ export default class KyveGovMsg {
     const tx = this.createGovTx(amount, content, options?.isExpedited);
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async updatePoolProposal(
+  public updatePoolProposal(
     amount: string,
     value: UpdatePoolProposal,
     options?: {
@@ -94,11 +94,11 @@ export default class KyveGovMsg {
     const tx = this.createGovTx(amount, content, options?.isExpedited);
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async pausePoolProposal(
+  public pausePoolProposal(
     amount: string,
     value: PausePoolProposal,
     options?: {
@@ -114,11 +114,11 @@ export default class KyveGovMsg {
     const tx = this.createGovTx(amount, content, options?.isExpedited);
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async unpausePoolProposal(
+  public unpausePoolProposal(
     amount: string,
     value: UnpausePoolProposal,
     options?: {
@@ -134,11 +134,11 @@ export default class KyveGovMsg {
     const tx = this.createGovTx(amount, content, options?.isExpedited);
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async schedulePoolUpgradeProposal(
+  public schedulePoolUpgradeProposal(
     amount: string,
     value: SchedulePoolUpgradeProposal,
     options?: {
@@ -154,11 +154,11 @@ export default class KyveGovMsg {
     const tx = this.createGovTx(amount, content, options?.isExpedited);
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 
-  public async cancelPoolUpgradeProposal(
+  public cancelPoolUpgradeProposal(
     amount: string,
     value: CancelPoolUpgradeProposal,
     options: {
@@ -174,7 +174,7 @@ export default class KyveGovMsg {
     const tx = this.createGovTx(amount, content, options?.isExpedited);
     return new TxPromise(
       this.nativeClient,
-      await signTx(this.nativeClient, this.account.address, tx, options)
+        () =>  signTx(this.nativeClient, this.account.address, tx, options)
     );
   }
 }

--- a/test/unit/kyve-client.test.ts
+++ b/test/unit/kyve-client.test.ts
@@ -145,13 +145,16 @@ let kyveClient: KyveClient;
 let mockSign: Mock;
 let mockSendTokens: Mock;
 let mockGetBalance: Mock;
+let mockBTx: Mock;
 beforeEach(() => {
   mockSign = jest.fn(() => TxRaw.create());
   mockSendTokens = jest.fn();
+  mockBTx = jest.fn();
   mockGetBalance = jest.fn(() => ({ amount: 0 }));
   const mockNativeClient = {
     simulate: () => Promise.resolve(1),
     sign: mockSign,
+    broadcastTx: mockBTx,
     sendTokens: mockSendTokens,
     getBalance: mockGetBalance,
   } as unknown as SigningStargateClient;


### PR DESCRIPTION
thenable approach 
Example: 
```
(async function () {
    const sdk = new KyveSDK("alpha");
    const kyveClient = await sdk.fromMnemonic(TEST_MNEMONIC);
    //execute immediately
    const tx = await kyveClient.kyve.v1beta1.gov.submitTextProposal('100000', {
        title: '123123',
        description: '123123'
    }, {memo: "memos"})
   
    console.log(tx) //tx is a DeliverTxResponse
    
    //does not execute immediately
    const tx2 =  kyveClient.kyve.v1beta1.gov.submitTextProposal('100000', {
        title: '123123',
        description: '123123'
    }, {memo: "memos"})
   
    console.log(tx2) //tx is a TxPromise type 
    const hash = await tx2.getTxHash()
    //execute tx 
    await tx2.execute() //return a  DeliverTxResponse
})()
```